### PR TITLE
Workflows/testing

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -23,6 +23,7 @@ jobs:
                   path: |
                       ~/.cargo/registry
                       ~/.cargo/git
+                      ~/.cargo/bin
                       target
                   key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -31,6 +31,7 @@ jobs:
               run: sudo apt-get install -y llvm clang
 
             - name: Install cargo-tarpaulin
+              if: steps.cache.outputs.cache-hit != 'true'
               run: cargo install cargo-tarpaulin
 
             - name: Run tests with code coverage

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -28,6 +28,7 @@ jobs:
                   key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
             - name: Set up Rust
+              if: steps.cache.outputs.cache-hit != 'true'
               uses: actions-rs/toolchain@v1
               with:
                   toolchain: stable

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -27,8 +27,10 @@ jobs:
                       target
                   key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-            - name: Install LLVM and Clang
-              run: sudo apt-get install -y llvm clang
+            - name: Set up Rust
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
 
             - name: Install cargo-tarpaulin
               if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Feat:
- GitHub actions now caches binaries to speed up execution
- Set up Rust skips if cached
- Install cargo-tarpaulin skips if cached

This makes testing checks much faster, ~45 seconds down from ~5 minutes
![image](https://github.com/MakeShiftArtist/rusty-snowflake/assets/47653736/dba81fa8-ce0c-46ee-88ca-6a55ec16ad44)
